### PR TITLE
Loosen up the version dependencies

### DIFF
--- a/org.sonatype.m2e.webby.feature/feature.xml
+++ b/org.sonatype.m2e.webby.feature/feature.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <!--
  ~ Copyright (c) 2011 Sonatype, Inc.
  ~ All rights reserved. This program and the accompanying materials
@@ -7,7 +6,6 @@
  ~ which accompanies this distribution, and is available at
  ~   http://www.eclipse.org/legal/epl-v10.html
 -->
-
 <feature
       id="org.sonatype.m2e.webby.feature"
       label="Web Application Runner"
@@ -33,7 +31,7 @@
 
    <requires>
       <import feature="org.eclipse.platform" version="3.4.0" match="greaterOrEqual"/>
-      <import feature="org.eclipse.m2e.feature"/>
+      <import feature="org.eclipse.m2e.feature" version="1.0.0" match="greaterOrEqual"/>
    </requires>
 
    <plugin

--- a/org.sonatype.m2e.webby/META-INF/MANIFEST.MF
+++ b/org.sonatype.m2e.webby/META-INF/MANIFEST.MF
@@ -20,9 +20,9 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.jdt.debug.ui,
  org.eclipse.jdt.launching,
  org.eclipse.jdt.ui,
- org.eclipse.m2e.core;bundle-version="[1.0.0,1.1.0)",
- org.eclipse.m2e.maven.runtime;bundle-version="[1.0.0,1.1.0)",
- org.eclipse.m2e.jdt;bundle-version="[1.0.0,1.1.0)"
+ org.eclipse.m2e.core;bundle-version="[1.0.0,2.0.0)",
+ org.eclipse.m2e.maven.runtime;bundle-version="[1.0.0,2.0.0)",
+ org.eclipse.m2e.jdt;bundle-version="[1.0.0,2.0.0)"
 Bundle-ClassPath: .,jars/maven-filtering-1.0.jar,
  jars/cargo/cargo-core-uberjar-1.1.3-948-SNAPSHOT.jar,
  jars/cargo/ant-1.8.2.jar,


### PR DESCRIPTION
This makes a few changes to the Manifest and Feature.xml to allow
for a looser version range.  Minimum is still required for 1.0.0 but
the upper range is less than 2.0.0.
