### PR TITLE
static resources are not copied under m2e-webby #6

### DIFF
--- a/org.sonatype.m2e.webby/src/org/sonatype/m2e/webby/internal/util/PathCollector.java
+++ b/org.sonatype.m2e.webby/src/org/sonatype/m2e/webby/internal/util/PathCollector.java
@@ -39,6 +39,7 @@ public class PathCollector {
       scanner.setExcludes(new String[0]);
     }
     scanner.addDefaultExcludes();
+    scanner.setupMatchPatterns();
   }
 
   public String[] collectFiles(String basedir) {
@@ -136,6 +137,10 @@ public class PathCollector {
       return isIncluded(path) && !isExcluded(path);
     }
 
+    @Override
+    public void setupMatchPatterns() {
+    	super.setupMatchPatterns();
+    }
   }
 
 }


### PR DESCRIPTION
couldHoldIncluded throws a NullPointerException cause includesPatterns is null.

I just added scanner.setupMatchPatterns(); to populate It at the end of  PathCollector's constructor.

Fixed Issue under NullPointerException :
17:48:34.623 [Worker-6] DEBUG o.e.m.c.i.builder.MavenBuilderImpl -
Exception in build participant
org.sonatype.m2e.webby.internal.build.WebbyBuildParticipant
java.lang.NullPointerException: null
    at
org.codehaus.plexus.util.AbstractScanner.couldHoldIncluded(AbstractScanner.java:363)
~[plexus-utils-3.0.17.jar:na]
    at
org.sonatype.m2e.webby.internal.util.PathCollector$DirectoryScannerEx.couldHoldIncluded(PathCollector.java:132)
~[na:na]
    at
org.sonatype.m2e.webby.internal.util.PathCollector$1.visit(PathCollector.java:80)
~[na:na]
